### PR TITLE
Release/0.0.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,1 @@
-No changes found
+- fix: Add debug statements for release commands

--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,21 @@
+# 0.0.5 (2025-02-13)
+
+- fix: Correct branch reference in changelog retrieval
+
+- - Update comment to reference main branch
+
+- - Change git log command from develop to main
+
+- chore: Bump version and improve changelog
+
+- - Update package.json to version 0.0.3
+
+- - Enhance getChangelog function
+
+- - Update changelog.md
+
 - fix: Add debug statements for release commands
+
+- - Insert FIXME and console.log in bump-version.ts
+
+- - Insert FIXME and console.log in release.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitaid",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "gitaid – AI-powered Commit Message Generator",
   "main": "dist/cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitaid",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "gitaid – AI-powered Commit Message Generator",
   "main": "dist/cli.js",
   "bin": {

--- a/src/commands/release/bump-version.ts
+++ b/src/commands/release/bump-version.ts
@@ -10,6 +10,9 @@ export async function bumpVersion(bumpType: 'major' | 'minor' | 'patch'): Promis
     if (!existsSync(pkgPath)) {
         console.log('package.json not found, skipping version bump.');
         return null;
+
+        // FIXME:
+        console.log(916);
     }
     try {
         const data = await fs.readFile(pkgPath, 'utf-8');

--- a/src/commands/release/get-changelog.ts
+++ b/src/commands/release/get-changelog.ts
@@ -6,8 +6,8 @@ import { execSync } from 'child_process';
 export function getChangelog(version: string): string {
     try {
         const releaseBranch = `release/${version}`;
-        // Get full commit messages including body between develop and release branch
-        const commits = execSync(`git log develop..${releaseBranch} --pretty=format:"%s%n%n%b" --no-merges`, {
+        // Get full commit messages including body between main and release branch
+        const commits = execSync(`git log main..${releaseBranch} --pretty=format:"%s%n%n%b" --no-merges`, {
             encoding: 'utf-8'
         }).trim();
 

--- a/src/commands/release/release.ts
+++ b/src/commands/release/release.ts
@@ -6,6 +6,9 @@ import { writeChangelog } from './write-changelog.js';
 
 const releaseCommand = new Command('release');
 
+// FIXME:
+console.log(456);
+
 releaseCommand
     .argument('[bump]', 'version bump type (major, minor, patch)', 'patch')
     .option('--from <branch>', 'Base branch to create release branch from', 'develop')

--- a/src/commands/release/release.ts
+++ b/src/commands/release/release.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { Command } from 'commander';
 import { bumpVersion } from './bump-version.js';
 import { createReleaseBranch } from './create-release-branch.js';
@@ -32,8 +33,18 @@ releaseCommand
         try {
             const changelog = await getChangelog(newVersion);
             await writeChangelog(changelog);
+
+            // Push changes to origin
+            const releaseBranch = `release/${newVersion}`;
+            execSync(
+                `git add changelog.md && git commit -m "docs: Update changelog for version ${newVersion}" && git push origin ${releaseBranch}`,
+                {
+                    stdio: 'inherit'
+                }
+            );
+            console.log(`Changes pushed to origin/${releaseBranch}`);
         } catch (error) {
-            console.error('Error generating changelog:', error);
+            console.error('Error in release process:', error);
             process.exit(1);
         }
     });


### PR DESCRIPTION
# 0.0.5 (2025-02-13)

- fix: Correct branch reference in changelog retrieval

  - Update comment to reference main branch

  - Change git log command from develop to main

- chore: Bump version and improve changelog

  - Update package.json to version 0.0.3

  - Enhance getChangelog function

- - Update changelog.md

- fix: Add debug statements for release commands

- - Insert FIXME and console.log in bump-version.ts

- - Insert FIXME and console.log in release.ts
