### PR TITLE
Release/0.0.11

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,27 @@
+# 0.0.11 (2025-02-13)
+
+- refactor: Improve changelog subject formatting
+    - Trim subject lines
+
+- Prefix with dash if missing
+
+- Update return statements with formatted subject
+
+- refactor: Simplify list item formatting in changelog generator
+    - Replace regex /^- .+/ with line[0] === '-'
+
+- Adjust list item formatting logic
+
+- fix: Ensure proper formatting of changelog list items
+    - Update regex to detect properly formatted list items
+
+- Remove existing dashes and reformat list items
+
+- fix: Correct changelog formatting
+    - Preserve existing list items
+
+- Add dashes to non-list lines
+
 # 0.0.10 (2025-02-13)
 
 - refactor: Improve changelog formatting and generation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitaid",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "gitaid – AI-powered Commit Message Generator",
   "main": "dist/cli.js",
   "bin": {

--- a/src/commands/release/get-changelog.ts
+++ b/src/commands/release/get-changelog.ts
@@ -31,7 +31,17 @@ export function getChangelog(version: string): string {
                     return `- ${subject}`;
                 }
 
-                const formattedBody = body.map((line) => `    ${line.trim()}`).join('\n');
+                const formattedBody = body
+                    .map((line) => {
+                        const trimmedLine = line.trim();
+                        // If line already starts with a dash, just add indentation
+                        if (trimmedLine.startsWith('-')) {
+                            return `    ${trimmedLine}`;
+                        }
+                        // Otherwise add indentation and a dash
+                        return `    - ${trimmedLine}`;
+                    })
+                    .join('\n');
 
                 return `- ${subject}\n${formattedBody}`;
             })

--- a/src/commands/release/get-changelog.ts
+++ b/src/commands/release/get-changelog.ts
@@ -35,11 +35,12 @@ export function getChangelog(version: string): string {
                     .map((line) => {
                         const trimmedLine = line.trim();
                         // Check if line is already a properly formatted list item
-                        if (/^- .+/.test(trimmedLine)) {
+                        if (line[0] === '-') {
                             return `    ${trimmedLine}`;
+                        } else {
+                            // Remove any existing dashes and add proper list item format
+                            return `    - ${trimmedLine.replace(/^-+\s*/, '')}`;
                         }
-                        // Remove any existing dashes and add proper list item format
-                        return `    - ${trimmedLine.replace(/^-+\s*/, '')}`;
                     })
                     .join('\n');
 

--- a/src/commands/release/get-changelog.ts
+++ b/src/commands/release/get-changelog.ts
@@ -27,14 +27,18 @@ export function getChangelog(version: string): string {
                 if (lines.length === 0) return '';
 
                 const [subject, ...body] = lines;
+                const trimmedSubject = subject.trim();
+
+                // Format subject line - add dash if not present
+                const formattedSubject = trimmedSubject[0] === '-' ? trimmedSubject : `- ${trimmedSubject}`;
+
                 if (body.length === 0) {
-                    return `- ${subject}`;
+                    return formattedSubject;
                 }
 
                 const formattedBody = body
                     .map((line) => {
                         const trimmedLine = line.trim();
-                        // Check if line is already a properly formatted list item
                         if (line[0] === '-') {
                             return `    ${trimmedLine}`;
                         } else {
@@ -44,7 +48,7 @@ export function getChangelog(version: string): string {
                     })
                     .join('\n');
 
-                return `- ${subject}\n${formattedBody}`;
+                return `${formattedSubject}\n${formattedBody}`;
             })
             .filter(Boolean)
             .join('\n\n');

--- a/src/commands/release/get-changelog.ts
+++ b/src/commands/release/get-changelog.ts
@@ -34,12 +34,12 @@ export function getChangelog(version: string): string {
                 const formattedBody = body
                     .map((line) => {
                         const trimmedLine = line.trim();
-                        // If line already starts with a dash, just add indentation
-                        if (trimmedLine.startsWith('-')) {
+                        // Check if line is already a properly formatted list item
+                        if (/^- .+/.test(trimmedLine)) {
                             return `    ${trimmedLine}`;
                         }
-                        // Otherwise add indentation and a dash
-                        return `    - ${trimmedLine}`;
+                        // Remove any existing dashes and add proper list item format
+                        return `    - ${trimmedLine.replace(/^-+\s*/, '')}`;
                     })
                     .join('\n');
 


### PR DESCRIPTION
# 0.0.11 (2025-02-13)

- refactor: Improve changelog subject formatting
    - Trim subject lines

- Prefix with dash if missing

- Update return statements with formatted subject

- refactor: Simplify list item formatting in changelog generator
    - Replace regex /^- .+/ with line[0] === '-'

- Adjust list item formatting logic

- fix: Ensure proper formatting of changelog list items
    - Update regex to detect properly formatted list items

- Remove existing dashes and reformat list items

- fix: Correct changelog formatting
    - Preserve existing list items

- Add dashes to non-list lines